### PR TITLE
Update signature of cont function

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,16 +20,12 @@ def testModels(filename="tests/HD170740_w860_redl_20140915_O12.fits"):
 
     with pytest.raises(TypeError):
         assert ContinuumModel()
-    with pytest.raises(TypeError):
-        assert ContinuumModel(n_anchors=11)
 
     cont_pars = cont_model.guess(sp.flux, x=sp.wave)
     assert len(cont_pars) == len(cont_model.param_names)
 
     for name in cont_model.param_names:
         assert cont_pars[name].value is not None
-
-
 
     voigt = VoigtModel(prefix='voigt_')
     assert voigt.prefix == 'voigt_'


### PR DESCRIPTION
Update the signature of the cont function in the ContinuumModel class from (x, **kwargs) to (x, y_0, y_1, ... x_0, x_1, ...). Using **kwargs in the function definition and updating the signature (which lmfit reads to create its parameters) lets us add an unknown number of continuum anchor points, where as using a set number of x and y anchor points in the function definition is ugly and limits us to a specific number of anchor points (previously 10). 